### PR TITLE
Hotfix: dynamic BIP44 coin type

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2,11 +2,12 @@ package client
 
 import (
 	"fmt"
+	"os"
 
-	"github.com/binance-chain/bep3-deputy/util"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/tendermint/go-amino"
+	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/rpc/client"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	tmtypes "github.com/tendermint/tendermint/types"
@@ -22,13 +23,13 @@ type KavaClient struct {
 }
 
 // NewKavaClient creates a new KavaClient
-func NewKavaClient(cdc *amino.Codec, mnemonic string, rpcAddr string, networkType ChainNetwork) *KavaClient {
+func NewKavaClient(cdc *amino.Codec, mnemonic string, coinID uint32, rpcAddr string, networkType ChainNetwork) *KavaClient {
 	// Set up HTTP client
 	http := client.NewHTTP(rpcAddr, "/websocket")
-	http.Logger = util.SdkLogger
+	http.Logger = log.NewTMLogger(log.NewSyncWriter(os.Stdout))
 
 	// Set up key manager
-	keyManager, err := keys.NewMnemonicKeyManager(mnemonic)
+	keyManager, err := keys.NewMnemonicKeyManager(mnemonic, coinID)
 	if err != nil {
 		panic(fmt.Sprintf("new key manager from mnenomic err, err=%s", err.Error()))
 	}

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -23,9 +23,8 @@ import (
 
 const (
 	defaultBIP39Passphrase = ""
-	BIP44Prefix            = "44'/118'/"
+	PartialBIP44Prefix     = "44"
 	PartialPath            = "0'/0/0"
-	FullPath               = BIP44Prefix + PartialPath
 )
 
 // KeyManager is an interface for common methods on KeyManagers
@@ -38,9 +37,12 @@ type KeyManager interface {
 }
 
 // NewMnemonicKeyManager creates a new KeyManager from a mnenomic
-func NewMnemonicKeyManager(mnemonic string) (KeyManager, error) {
+func NewMnemonicKeyManager(mnemonic string, coinID uint32) (KeyManager, error) {
+	fullBIP44Prefix := fmt.Sprintf("%s'/%d'/", PartialBIP44Prefix, coinID)
+	fullPath := fullBIP44Prefix + PartialPath
+
 	k := keyManager{}
-	err := k.recoveryFromMnemonic(mnemonic, FullPath)
+	err := k.recoveryFromMnemonic(mnemonic, fullPath)
 	return &k, err
 }
 


### PR DESCRIPTION
This PR brings the go-sdk's KeyManager up to date with the Kava blockchain by supporting dynamic BIP44 coin types. This makes the go-sdk compatible with the changes in https://github.com/Kava-Labs/kava/pull/364.