### PR TITLE
R4R: add chain ID kava-testnet-5000

### DIFF
--- a/client/types.go
+++ b/client/types.go
@@ -18,6 +18,7 @@ const (
 )
 
 const (
-	ProdChainID = "testing"
 	TestChainID = "testing"
+	// ProdChainID is currently set to testnet-5000
+	ProdChainID = "kava-testnet-5000"
 )

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -9,6 +9,7 @@ import (
 const (
 	TestMnenomic     = "equip town gesture square tomorrow volume nephew minute witness beef rich gadget actress egg sing secret pole winter alarm law today check violin uncover"
 	TestExpectedAddr = "kava15qdefkmwswysgg4qxgqpqr35k3m49pkx2jdfnw"
+	TestKavaCoinID   = 459
 )
 
 func TestNewMnemonicKeyManager(t *testing.T) {
@@ -16,14 +17,15 @@ func TestNewMnemonicKeyManager(t *testing.T) {
 	tests := []struct {
 		name       string
 		mnenomic   string
+		coinID     uint32
 		expectpass bool
 	}{
-		{"normal", TestMnenomic, true},
+		{"normal", TestMnenomic, TestKavaCoinID, true},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			keyManager, err := NewMnemonicKeyManager(tc.mnenomic)
+			keyManager, err := NewMnemonicKeyManager(tc.mnenomic, tc.coinID)
 
 			if tc.expectpass {
 				require.Nil(t, err)


### PR DESCRIPTION
This PR adds chain ID for testnet 5000. It includes updated tests for the KeyManager.