### PR TITLE
Drop transaction fee

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -100,7 +100,7 @@ func (kc *KavaClient) sign(m sdk.Msg) ([]byte, error) {
 		ChainID:       chainID,
 		AccountNumber: 0,
 		Sequence:      0,
-		Fee:           authtypes.NewStdFee(200000, sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(250000)))),
+		Fee:           authtypes.NewStdFee(250000, nil),
 		Msgs:          []sdk.Msg{m},
 		Memo:          "",
 	}


### PR DESCRIPTION
Removes the default transaction fee from tx sign/broadcast. Also increased the gas limit from 200k to 250k to support gas-expensive msgs, such as MsgCreateCDP.