### PR TITLE
Fetch Chain ID

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -17,14 +17,13 @@ import (
 
 // KavaClient facilitates interaction with the Kava blockchain
 type KavaClient struct {
-	Network ChainNetwork
 	HTTP    *rpcclient.HTTP
 	Keybase keys.KeyManager
 	Cdc     *amino.Codec
 }
 
 // NewKavaClient creates a new KavaClient
-func NewKavaClient(cdc *amino.Codec, mnemonic string, coinID uint32, rpcAddr string, networkType ChainNetwork) *KavaClient {
+func NewKavaClient(cdc *amino.Codec, mnemonic string, coinID uint32, rpcAddr string) *KavaClient {
 	// Set up HTTP client
 	http, err := rpcclient.NewHTTP(rpcAddr, "/websocket")
 	if err != nil {
@@ -39,7 +38,6 @@ func NewKavaClient(cdc *amino.Codec, mnemonic string, coinID uint32, rpcAddr str
 	}
 
 	return &KavaClient{
-		Network: networkType,
 		HTTP:    http,
 		Keybase: keyManager,
 		Cdc:     cdc,

--- a/client/client.go
+++ b/client/client.go
@@ -86,14 +86,9 @@ func (kc *KavaClient) sign(m sdk.Msg) ([]byte, error) {
 		return nil, fmt.Errorf("Keys are missing, must to set key")
 	}
 
-	var chainID string
-	switch kc.Network {
-	case LocalNetwork:
-		chainID = LocalChainID
-	case TestNetwork:
-		chainID = TestChainID
-	case ProdNetwork:
-		chainID = ProdChainID
+	chainID, err := kc.GetChainID()
+	if err != nil {
+		return nil, fmt.Errorf("could not fetch chain id: %w", err)
 	}
 
 	signMsg := &authtypes.StdSignMsg{

--- a/client/queries.go
+++ b/client/queries.go
@@ -56,6 +56,14 @@ func (kc *KavaClient) GetAccount(addr sdk.AccAddress) (acc authtypes.BaseAccount
 	return acc, err
 }
 
+func (kc *KavaClient) GetChainID() (string, error) {
+	result, err := kc.HTTP.Status()
+	if err != nil {
+		return "", err
+	}
+	return result.NodeInfo.Network, nil
+}
+
 // ABCIQuery sends a query to Kava
 func (kc *KavaClient) ABCIQuery(path string, data tmbytes.HexBytes) ([]byte, error) {
 	if err := ValidateABCIQuery(path, data); err != nil {

--- a/client/types.go
+++ b/client/types.go
@@ -8,21 +8,3 @@ const (
 	Sync
 	Commit
 )
-
-// ChainNetwork is the name of the blockchain
-type ChainNetwork uint8
-
-const (
-	LocalNetwork ChainNetwork = iota
-	TestNetwork
-	ProdNetwork
-)
-
-const (
-	// LocalChainID is for local development
-	LocalChainID = "testing"
-	// TestChainID is Kava's latest testnet
-	TestChainID = "kava-testnet-6000"
-	// ProdChainID is Kava's mainnet
-	ProdChainID = "kava-3"
-)

--- a/kava/committee/permisisons.go
+++ b/kava/committee/permisisons.go
@@ -378,8 +378,8 @@ type AllowedCollateralParam struct {
 	AuctionSize         bool   `json:"auction_size" yaml:"auction_size"`
 	LiquidationPenalty  bool   `json:"liquidation_penalty" yaml:"liquidation_penalty"`
 	Prefix              bool   `json:"prefix" yaml:"prefix"`
-	SpotMarketID        bool   `json:"market_id" yaml:"market_id"`
-	LiquidationMarketID bool   `json:"market_id" yaml:"market_id"`
+	SpotMarketID        bool   `json:"spot_market_id" yaml:"spot_market_id"`
+	LiquidationMarketID bool   `json:"liquidation_market_id" yaml:"liquidation_market_id"`
 	ConversionFactor    bool   `json:"conversion_factor" yaml:"conversion_factor"`
 }
 


### PR DESCRIPTION
Fetch the chain ID from the rpc endpoint rather than hardcoding possible values.
This makes the sdk work with any kava chain:  mainnet, testnet, or localnets. It also removes the need for the `Network` parameter.